### PR TITLE
Rework from Size animations to Scale animations, add StackAlignment + StackDensity

### DIFF
--- a/lib/src/animations.dart
+++ b/lib/src/animations.dart
@@ -17,6 +17,21 @@ class CardSizes {
   }
 }
 
+/// Card Scales
+class CardScales {
+  static double front(BoxConstraints constraints) {
+    return 1;
+  }
+
+  static double middle(BoxConstraints constraints) {
+    return 0.95;
+  }
+
+  static double back(BoxConstraints constraints) {
+    return 0.85;
+  }
+}
+
 /// Stack density {
 enum StackDensity {
   COMPACT,
@@ -75,6 +90,21 @@ class CardAnimations {
     );
   }
 
+  static Animation<double> middleCardScaleAnimation(
+    AnimationController parent,
+    BoxConstraints constraints,
+  ) {
+    return Tween<double>(
+      begin: CardScales.middle(constraints),
+      end: CardScales.front(constraints),
+    ).animate(
+      CurvedAnimation(
+        parent: parent,
+        curve: Interval(0.2, 0.5, curve: Curves.easeIn),
+      ),
+    );
+  }
+
   /// 中间卡片尺寸变换动画
   static Animation<Size?> middleCardSizeAnimation(
     AnimationController parent,
@@ -114,6 +144,21 @@ class CardAnimations {
     return SizeTween(
       begin: CardSizes.back(constraints),
       end: CardSizes.middle(constraints),
+    ).animate(
+      CurvedAnimation(
+        parent: parent,
+        curve: Interval(0.4, 0.7, curve: Curves.easeIn),
+      ),
+    );
+  }
+
+  static Animation<double> backCardScaleAnimation(
+    AnimationController parent,
+    BoxConstraints constraints,
+  ) {
+    return Tween<double>(
+      begin: CardScales.back(constraints),
+      end: CardScales.middle(constraints),
     ).animate(
       CurvedAnimation(
         parent: parent,

--- a/lib/src/animations.dart
+++ b/lib/src/animations.dart
@@ -16,11 +16,11 @@ class CardScales {
   }
 
   static double middle(BoxConstraints constraints) {
-    return 0.95;
+    return 0.93;
   }
 
   static double back(BoxConstraints constraints) {
-    return 0.9;
+    return 0.86;
   }
 }
 
@@ -38,9 +38,9 @@ class CardAlignments {
   static Alignment middle = Alignment(stackAlignment.x / -6, 0.0);
 
   static Alignment front = Alignment(stackAlignment.x / 2,
-      stackAlignment.y / ((stackDensity == StackDensity.STANDARD) ? 1 : 2));
+      stackAlignment.y / ((stackDensity == StackDensity.STANDARD) ? 1 : 1.6));
   static Alignment back = Alignment(stackAlignment.x / -2,
-      stackAlignment.y / ((stackDensity == StackDensity.STANDARD) ? -1 : -2));
+      stackAlignment.y / ((stackDensity == StackDensity.STANDARD) ? -1 : -1.6));
 }
 
 /// Card Forward Animations

--- a/lib/src/animations.dart
+++ b/lib/src/animations.dart
@@ -17,16 +17,23 @@ class CardSizes {
   }
 }
 
+/// Stack density {
+enum StackDensity {
+  COMPACT,
+  STANDARD,
+}
+
 /// Card Alignments
 class CardAlignments {
   static Alignment stackAlignment = Alignment.topCenter;
+  static StackDensity stackDensity = StackDensity.COMPACT;
 
   static Alignment middle = Alignment(stackAlignment.x / -6, 0.0);
 
-  static Alignment front =
-      Alignment(stackAlignment.x / 2, stackAlignment.y / 2);
-  static Alignment back =
-      Alignment(stackAlignment.x / -2, stackAlignment.y / -2);
+  static Alignment front = Alignment(stackAlignment.x / 2,
+      stackAlignment.y / ((stackDensity == StackDensity.STANDARD) ? 2 : 4));
+  static Alignment back = Alignment(stackAlignment.x / -2,
+      stackAlignment.y / ((stackDensity == StackDensity.STANDARD) ? -2 : -4));
 }
 
 /// Card Forward Animations

--- a/lib/src/animations.dart
+++ b/lib/src/animations.dart
@@ -7,14 +7,6 @@ class CardSizes {
   static Size front(BoxConstraints constraints) {
     return Size(constraints.maxWidth * 0.9, constraints.maxHeight * 0.9);
   }
-
-  static Size middle(BoxConstraints constraints) {
-    return Size(constraints.maxWidth * 0.85, constraints.maxHeight * 0.9);
-  }
-
-  static Size back(BoxConstraints constraints) {
-    return Size(constraints.maxWidth * 0.8, constraints.maxHeight * .9);
-  }
 }
 
 /// Card Scales
@@ -28,7 +20,7 @@ class CardScales {
   }
 
   static double back(BoxConstraints constraints) {
-    return 0.85;
+    return 0.9;
   }
 }
 
@@ -46,9 +38,9 @@ class CardAlignments {
   static Alignment middle = Alignment(stackAlignment.x / -6, 0.0);
 
   static Alignment front = Alignment(stackAlignment.x / 2,
-      stackAlignment.y / ((stackDensity == StackDensity.STANDARD) ? 2 : 4));
+      stackAlignment.y / ((stackDensity == StackDensity.STANDARD) ? 1 : 2));
   static Alignment back = Alignment(stackAlignment.x / -2,
-      stackAlignment.y / ((stackDensity == StackDensity.STANDARD) ? -2 : -4));
+      stackAlignment.y / ((stackDensity == StackDensity.STANDARD) ? -1 : -2));
 }
 
 /// Card Forward Animations
@@ -105,22 +97,6 @@ class CardAnimations {
     );
   }
 
-  /// 中间卡片尺寸变换动画
-  static Animation<Size?> middleCardSizeAnimation(
-    AnimationController parent,
-    BoxConstraints constraints,
-  ) {
-    return SizeTween(
-      begin: CardSizes.middle(constraints),
-      end: CardSizes.front(constraints),
-    ).animate(
-      CurvedAnimation(
-        parent: parent,
-        curve: Interval(0.2, 0.5, curve: Curves.easeIn),
-      ),
-    );
-  }
-
   /// 最后面卡片位置变换动画
   static Animation<Alignment> backCardAlignmentAnimation(
     AnimationController parent,
@@ -128,22 +104,6 @@ class CardAnimations {
     return AlignmentTween(
       begin: CardAlignments.back,
       end: CardAlignments.middle,
-    ).animate(
-      CurvedAnimation(
-        parent: parent,
-        curve: Interval(0.4, 0.7, curve: Curves.easeIn),
-      ),
-    );
-  }
-
-  /// 最后面卡片尺寸变换动画
-  static Animation<Size?> backCardSizeAnimation(
-    AnimationController parent,
-    BoxConstraints constraints,
-  ) {
-    return SizeTween(
-      begin: CardSizes.back(constraints),
-      end: CardSizes.middle(constraints),
     ).animate(
       CurvedAnimation(
         parent: parent,
@@ -207,14 +167,13 @@ class CardReverseAnimations {
     );
   }
 
-  /// 中间卡片尺寸变换动画
-  static Animation<Size?> middleCardSizeAnimation(
+  static Animation<double> middleCardScaleAnimation(
     AnimationController parent,
     BoxConstraints constraints,
   ) {
-    return SizeTween(
-      begin: CardSizes.front(constraints),
-      end: CardSizes.middle(constraints),
+    return Tween<double>(
+      begin: CardScales.front(constraints),
+      end: CardScales.middle(constraints),
     ).animate(
       CurvedAnimation(
         parent: parent,
@@ -238,14 +197,13 @@ class CardReverseAnimations {
     );
   }
 
-  /// 最后面卡片尺寸变换动画
-  static Animation<Size?> backCardSizeAnimation(
+  static Animation<double> backCardScaleAnimation(
     AnimationController parent,
     BoxConstraints constraints,
   ) {
-    return SizeTween(
-      begin: CardSizes.middle(constraints),
-      end: CardSizes.back(constraints),
+    return Tween<double>(
+      begin: CardScales.middle(constraints),
+      end: CardScales.back(constraints),
     ).animate(
       CurvedAnimation(
         parent: parent,

--- a/lib/src/animations.dart
+++ b/lib/src/animations.dart
@@ -19,9 +19,14 @@ class CardSizes {
 
 /// Card Alignments
 class CardAlignments {
-  static Alignment front = Alignment(0.0, -0.5);
-  static Alignment middle = Alignment(0.0, 0.0);
-  static Alignment back = Alignment(0.0, 0.5);
+  static Alignment stackAlignment = Alignment.topCenter;
+
+  static Alignment middle = Alignment(stackAlignment.x / -6, 0.0);
+
+  static Alignment front =
+      Alignment(stackAlignment.x / 2, stackAlignment.y / 2);
+  static Alignment back =
+      Alignment(stackAlignment.x / -2, stackAlignment.y / -2);
 }
 
 /// Card Forward Animations

--- a/lib/src/cards.dart
+++ b/lib/src/cards.dart
@@ -171,9 +171,9 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
         alignment: CardReverseAnimations.middleCardAlignmentAnimation(
           _cardReverseController,
         ).value,
-        child: SizedBox.fromSize(
-          size: CardReverseAnimations.middleCardSizeAnimation(
-            _cardReverseController,
+        child: Transform.scale(
+          scale: CardReverseAnimations.middleCardScaleAnimation(
+            _cardChangeController,
             constraints,
           ).value,
           child: child,
@@ -184,24 +184,13 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
         alignment: CardAnimations.middleCardAlignmentAnimation(
           _cardChangeController,
         ).value,
-        child: AnimatedScale(
-          duration: Duration(milliseconds: 300),
+        child: Transform.scale(
           scale: CardAnimations.middleCardScaleAnimation(
             _cardChangeController,
             constraints,
           ).value,
           child: child,
         ),
-        /*
-        child: SizedBox.fromSize(
-          size: CardAnimations.middleCardSizeAnimation(
-            _cardChangeController,
-            constraints,
-          ).value,
-          child: child,
-        ),
-
-         */
       );
     } else {
       return Align(
@@ -210,12 +199,6 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
           scale: CardScales.middle(constraints),
           child: child,
         ),
-/*
-          SizedBox.fromSize(
-          size: CardSizes.middle(constraints),
-          child: child,
-        ),
-         */
       );
     }
   }
@@ -235,9 +218,9 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
         alignment: CardReverseAnimations.backCardAlignmentAnimation(
           _cardReverseController,
         ).value,
-        child: SizedBox.fromSize(
-          size: CardReverseAnimations.backCardSizeAnimation(
-            _cardReverseController,
+        child: Transform.scale(
+          scale: CardReverseAnimations.backCardScaleAnimation(
+            _cardChangeController,
             constraints,
           ).value,
           child: child,
@@ -248,24 +231,13 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
         alignment: CardAnimations.backCardAlignmentAnimation(
           _cardChangeController,
         ).value,
-        child: AnimatedScale(
-          duration: Duration(milliseconds: 300),
+        child: Transform.scale(
           scale: CardAnimations.backCardScaleAnimation(
             _cardChangeController,
             constraints,
           ).value,
           child: child,
         ),
-        /*
-        child: SizedBox.fromSize(
-          size: CardAnimations.backCardSizeAnimation(
-            _cardChangeController,
-            constraints,
-          ).value,
-          child: child,
-        ),
-
-         */
       );
     } else {
       return Align(
@@ -274,13 +246,6 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
           scale: CardScales.back(constraints),
           child: child,
         ),
-        /*
-        child: SizedBox.fromSize(
-          size: CardSizes.back(constraints),
-          child: child,
-        ),
-
-         */
       );
     }
   }

--- a/lib/src/cards.dart
+++ b/lib/src/cards.dart
@@ -46,6 +46,10 @@ class TCard extends StatefulWidget {
   /// Alignment.topCenter is the default
   final Alignment stackAlignment;
 
+  /// What should the offset between the cards in the stack be like
+  /// Default is STANDARD, but for less offset you can use COMPACT.
+  final StackDensity stackDensity;
+
   const TCard({
     required this.cards,
     this.leftIcon,
@@ -58,6 +62,7 @@ class TCard extends StatefulWidget {
     this.slideSpeed = 20,
     this.delaySlideFor = 500,
     this.stackAlignment = Alignment.topCenter,
+    this.stackDensity = StackDensity.STANDARD,
     this.size = const Size(380, 400),
   })  : assert(cards != null),
         assert(cards.length > 0);
@@ -406,6 +411,8 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
     super.initState();
 
     CardAlignments.stackAlignment = widget.stackAlignment;
+    CardAlignments.stackDensity = widget.stackDensity;
+
     _frontCardAlignment = CardAlignments.front;
 
     // 初始化所有传入的卡片
@@ -466,8 +473,6 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    CardAlignments.stackAlignment = widget.stackAlignment;
-
     return SizedBox.fromSize(
       size: widget.size,
       child: LayoutBuilder(

--- a/lib/src/cards.dart
+++ b/lib/src/cards.dart
@@ -42,6 +42,10 @@ class TCard extends StatefulWidget {
   /// How long does it have to wait until the next slide is sliable? less is quicker. 100 is fast enough. 500 is a bit slow.
   final int delaySlideFor;
 
+  /// How should the cards be stacked on top of each other?
+  /// Alignment.topCenter is the default
+  final Alignment stackAlignment;
+
   const TCard({
     required this.cards,
     this.leftIcon,
@@ -53,6 +57,7 @@ class TCard extends StatefulWidget {
     this.lockYAxis = false,
     this.slideSpeed = 20,
     this.delaySlideFor = 500,
+    this.stackAlignment = Alignment.topCenter,
     this.size = const Size(380, 400),
   })  : assert(cards != null),
         assert(cards.length > 0);
@@ -73,7 +78,7 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
   int get frontCardIndex => _frontCardIndex;
 
   // 最前面卡片的位置
-  Alignment _frontCardAlignment = CardAlignments.front;
+  late Alignment _frontCardAlignment;
   // 最前面卡片的旋转角度
   double _frontCardRotation = 0.0;
   double _opacity = 0.0;
@@ -120,7 +125,6 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
         ),
       ),
     );
-
     if (reverse) {
       return Align(
         alignment: CardReverseAnimations.frontCardShowAnimation(
@@ -401,6 +405,9 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
   void initState() {
     super.initState();
 
+    CardAlignments.stackAlignment = widget.stackAlignment;
+    _frontCardAlignment = CardAlignments.front;
+
     // 初始化所有传入的卡片
     _cards.addAll(widget.cards);
 
@@ -459,6 +466,8 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
+    CardAlignments.stackAlignment = widget.stackAlignment;
+
     return SizedBox.fromSize(
       size: widget.size,
       child: LayoutBuilder(

--- a/lib/src/cards.dart
+++ b/lib/src/cards.dart
@@ -164,6 +164,8 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
     bool forward = _cardChangeController.status == AnimationStatus.forward;
     bool reverse = _cardReverseController.status == AnimationStatus.forward;
 
+    child = SizedBox.fromSize(size: CardSizes.front(constraints), child: child);
+
     if (reverse) {
       return Align(
         alignment: CardReverseAnimations.middleCardAlignmentAnimation(
@@ -182,6 +184,15 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
         alignment: CardAnimations.middleCardAlignmentAnimation(
           _cardChangeController,
         ).value,
+        child: AnimatedScale(
+          duration: Duration(milliseconds: 300),
+          scale: CardAnimations.middleCardScaleAnimation(
+            _cardChangeController,
+            constraints,
+          ).value,
+          child: child,
+        ),
+        /*
         child: SizedBox.fromSize(
           size: CardAnimations.middleCardSizeAnimation(
             _cardChangeController,
@@ -189,14 +200,22 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
           ).value,
           child: child,
         ),
+
+         */
       );
     } else {
       return Align(
         alignment: CardAlignments.middle,
-        child: SizedBox.fromSize(
+        child: Transform.scale(
+          scale: CardScales.middle(constraints),
+          child: child,
+        ),
+/*
+          SizedBox.fromSize(
           size: CardSizes.middle(constraints),
           child: child,
         ),
+         */
       );
     }
   }
@@ -208,6 +227,8 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
         : Container();
     bool forward = _cardChangeController.status == AnimationStatus.forward;
     bool reverse = _cardReverseController.status == AnimationStatus.forward;
+
+    child = SizedBox.fromSize(size: CardSizes.front(constraints), child: child);
 
     if (reverse) {
       return Align(
@@ -227,6 +248,15 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
         alignment: CardAnimations.backCardAlignmentAnimation(
           _cardChangeController,
         ).value,
+        child: AnimatedScale(
+          duration: Duration(milliseconds: 300),
+          scale: CardAnimations.backCardScaleAnimation(
+            _cardChangeController,
+            constraints,
+          ).value,
+          child: child,
+        ),
+        /*
         child: SizedBox.fromSize(
           size: CardAnimations.backCardSizeAnimation(
             _cardChangeController,
@@ -234,14 +264,23 @@ class TCardState extends State<TCard> with TickerProviderStateMixin {
           ).value,
           child: child,
         ),
+
+         */
       );
     } else {
       return Align(
         alignment: CardAlignments.back,
+        child: Transform.scale(
+          scale: CardScales.back(constraints),
+          child: child,
+        ),
+        /*
         child: SizedBox.fromSize(
           size: CardSizes.back(constraints),
           child: child,
         ),
+
+         */
       );
     }
   }

--- a/lib/tcard.dart
+++ b/lib/tcard.dart
@@ -3,3 +3,4 @@ library tcard;
 export 'src/cards.dart';
 export 'src/swipe_info.dart';
 export 'src/controller.dart';
+export 'src/animations.dart';


### PR DESCRIPTION
This PR contains several changes:

- Rework to use Scale instead of Size for resizing middle and back cards.
The current Size method worked fine for images, but when embedding text in cards it caused issues do to text wrap as the container was resizing. I've reworked the resizing to use Scale animations instead.

- Added Stack Alignment & StackDensity
In the current implementation there's no way to change how the stack looks. Cards are always on top of each other, with the middle and back cards sticking out at the bottom of the widget.
With StackAlignment you can change where the middle and back cards peek out.
With StackDensity you can change how much the middle and back cards stick out.

I've tried to maintain as much similarity to the old (Size) resizing as possible, but it might introduce minor visual changes, so I would flag this as a breaking change.